### PR TITLE
Third actor undressing

### DIFF
--- a/scripts/source/OsexIntegrationMain.psc
+++ b/scripts/source/OsexIntegrationMain.psc
@@ -467,8 +467,6 @@ Bool Function StartScene(Actor Dom, Actor Sub, Bool zUndressDom = False, Bool zU
 
 	UndressDom = zUndressDom
 	UndressSub = zUndressSub
-	Debug.Trace("D: " + UndressDom)
-	Debug.Trace("S: " + UndressSub)
 	AnimateUndress = zAnimateUndress
 	StartingAnimation = zStartingAnimation
 	ThirdActor = zThirdActor

--- a/scripts/source/OsexIntegrationMain.psc
+++ b/scripts/source/OsexIntegrationMain.psc
@@ -117,6 +117,7 @@ GlobalVariable Timescale
 
 Bool UndressDom
 Bool UndressSub
+bool UndressThird
 Bool AnimateUndress
 String StartingAnimation
 Actor ThirdActor
@@ -132,6 +133,12 @@ Form SubArmor
 Form SubGlove
 Form SubBoot
 Form SubWep
+
+form ThirdHelm
+form ThirdArmor
+form ThirdGlove
+form ThirdBoot
+form ThirdWep
 
 Bool IsFreeCamming
 
@@ -443,7 +450,7 @@ Function StartReroutedScene()
 	StartScene(ReroutedDomActor,  ReroutedSubActor)
 EndFunction
 
-Bool Function StartScene(Actor Dom, Actor Sub, Bool zUndressDom = False, Bool zUndressSub = False, Bool zAnimateUndress = False, String zStartingAnimation = "", Actor zThirdActor = None, ObjectReference Bed = None, Bool Aggressive = False, Actor AggressingActor = None)
+Bool Function StartScene(Actor Dom, Actor Sub, Bool zUndressDom = False, Bool zUndressSub = False, Bool zAnimateUndress = False, String zStartingAnimation = "", Actor zThirdActor = None, ObjectReference Bed = None, Bool Aggressive = False, Actor AggressingActor = None, bool zUndressThird = false)
 	If (SceneRunning)
 		Debug.Notification("Osex scene already running")
 		Return False
@@ -461,6 +468,7 @@ Bool Function StartScene(Actor Dom, Actor Sub, Bool zUndressDom = False, Bool zU
 
 	UndressDom = zUndressDom
 	UndressSub = zUndressSub
+	UndressThird = zUndressThird
 	AnimateUndress = zAnimateUndress
 	StartingAnimation = zStartingAnimation
 	ThirdActor = zThirdActor
@@ -710,6 +718,42 @@ Event OnUpdate()
 			EndIf
 		EndIf
 	EndIf
+
+	if (UndressThird)
+		; undressing really needs to be its own function.
+		ThirdArmor = ThirdActor.GetWornForm(0x00000004)
+		ThirdHelm = ThirdActor.GetWornForm(0x00000002)
+		ThirdGlove = ThirdActor.GetWornForm(0x00000080)
+		ThirdBoot = ThirdActor.GetWornForm(0x00000008)
+		ThirdWep = ThirdActor.GetEquippedObject(1)
+		if (AnimateUndress)
+			if (OnlyUndressChest)
+				AnimateUndressActor(ThirdActor, "cuirass")
+			Else
+				;animateUndressActor(ThirdActor, "helmet")
+				;animateUndressActor(ThirdActor, "gloves")
+				;animateUndressActor(ThirdActor, "weapon")
+				;animateUndressActor(ThirdActor, "boots")
+
+				AnimateUndressActor(ThirdActor, "cuirass")
+				UndressActor(ThirdActor, ThirdHelm)
+				UndressActor(ThirdActor, ThirdBoot)
+				UndressActor(ThirdActor, ThirdGlove)
+				ThirdActor.UnequipItem(ThirdWep, abPreventEquip = False, abSilent = True)
+			endif
+			
+		Else
+			if (OnlyUndressChest)
+				undressActor(ThirdActor, ThirdArmor)
+			Else
+				UndressActor(ThirdActor, ThirdHelm)
+				UndressActor(ThirdActor, ThirdBoot)
+				UndressActor(ThirdActor, ThirdGlove)
+				UndressActor(ThirdActor, ThirdArmor)
+				ThirdActor.UnequipItem(ThirdWep, abPreventEquip = False, abSilent = True)
+			endif
+		endif
+	endIf
 
 	StartTime = Utility.GetCurrentRealTime()
 
@@ -1702,6 +1746,22 @@ Function Redress()
 	If (SubWep)
 		SubActor.EquipItem(SubWep, False, True)
 	EndIf
+	If (ThirdHelm)
+		ThirdActor.EquipItem(ThirdHelm, False, True)
+	EndIf
+	If (ThirdGlove)
+		ThirdActor.EquipItem(ThirdGlove, False, True)
+	EndIf
+	If (ThirdArmor)
+		ThirdActor.EquipItem(ThirdArmor, False, True)
+	EndIf
+	If (ThirdBoot)
+		ThirdActor.EquipItem(ThirdBoot, False, True)
+	EndIf
+	If (ThirdWep)
+		ThirdActor.EquipItem(ThirdWep, False, True)
+	EndIf
+	; This can't possibly be the best way to do this.
 EndFunction
 
 Event OnActorHit(String EventName, String zAnimation, Float NumArg, Form Sender)

--- a/scripts/source/OsexIntegrationMain.psc
+++ b/scripts/source/OsexIntegrationMain.psc
@@ -450,7 +450,7 @@ Function StartReroutedScene()
 	StartScene(ReroutedDomActor,  ReroutedSubActor)
 EndFunction
 
-Bool Function StartScene(Actor Dom, Actor Sub, Bool zUndressDom = False, Bool zUndressSub = False, Bool zAnimateUndress = False, String zStartingAnimation = "", Actor zThirdActor = None, ObjectReference Bed = None, Bool Aggressive = False, Actor AggressingActor = None, bool zUndressThird = false)
+Bool Function StartScene(Actor Dom, Actor Sub, Bool zUndressDom = False, Bool zUndressSub = False, Bool zAnimateUndress = False, String zStartingAnimation = "", Actor zThirdActor = None, ObjectReference Bed = None, Bool Aggressive = False, Actor AggressingActor = None)
 	If (SceneRunning)
 		Debug.Notification("Osex scene already running")
 		Return False
@@ -468,7 +468,8 @@ Bool Function StartScene(Actor Dom, Actor Sub, Bool zUndressDom = False, Bool zU
 
 	UndressDom = zUndressDom
 	UndressSub = zUndressSub
-	UndressThird = zUndressThird
+	; Assume if sub is to be undressed, third actor should also be.
+	UndressThird = zUndressSub
 	AnimateUndress = zAnimateUndress
 	StartingAnimation = zStartingAnimation
 	ThirdActor = zThirdActor

--- a/scripts/source/OsexIntegrationMain.psc
+++ b/scripts/source/OsexIntegrationMain.psc
@@ -117,7 +117,6 @@ GlobalVariable Timescale
 
 Bool UndressDom
 Bool UndressSub
-bool UndressThird
 Bool AnimateUndress
 String StartingAnimation
 Actor ThirdActor
@@ -468,8 +467,8 @@ Bool Function StartScene(Actor Dom, Actor Sub, Bool zUndressDom = False, Bool zU
 
 	UndressDom = zUndressDom
 	UndressSub = zUndressSub
-	; Assume if sub is to be undressed, third actor should also be.
-	UndressThird = zUndressSub
+	Debug.Trace("D: " + UndressDom)
+	Debug.Trace("S: " + UndressSub)
 	AnimateUndress = zAnimateUndress
 	StartingAnimation = zStartingAnimation
 	ThirdActor = zThirdActor
@@ -719,8 +718,9 @@ Event OnUpdate()
 			EndIf
 		EndIf
 	EndIf
-
-	if (UndressThird)
+	
+	; Assume if sub is to be undressed, third actor should also be provided ThirdActor exists.
+	if (UndressSub == True && ThirdActor != None)
 		; undressing really needs to be its own function.
 		ThirdArmor = ThirdActor.GetWornForm(0x00000004)
 		ThirdHelm = ThirdActor.GetWornForm(0x00000002)


### PR DESCRIPTION
I've now fixed my test environment and run a test.
Tested with standard two person and three person scenes, no unexpected behaviour as far as I can tell.
Third actor is stripped and re-clothed during three person scenes correctly.

Logic is as follows:
If the sub actor is stripped, and a third actor exists also strip them.