### PR TITLE
Fixed import null bug.

### DIFF
--- a/Scripts/Source/OSexIntegrationMCM.psc
+++ b/Scripts/Source/OSexIntegrationMCM.psc
@@ -860,9 +860,12 @@ EndFunction
 Function ImportSettings()
 	; Import from file.
 	int OstimSettingsFile = JValue.readFromFile(JContainers.UserDirectory() + "OstimMCMSettings.json")
-	
-	Debug.MessageBox("Importing from file, wait a second or two before clicking OK.")
-	
+	if (OstimSettingsFile == False)
+		Debug.MessageBox("Tried to import from file, but no file existed.")
+		return
+	Else
+		Debug.MessageBox("Importing from file, wait a second or two before clicking OK.")
+	EndIf
 	; Sex settings import.
 	Main.EndOnDomOrgasm = Jmap.GetInt(OstimSettingsFile, "SetEndOnOrgasm")
 	Main.EnableActorSpeedControl = JMap.GetInt(OstimSettingsFile, "SetActorSpeedControl")


### PR DESCRIPTION
If you tried to import setting file when none existed, it would set every mcm value to none. Even the ones where that wouldn't make sense, so it very badly broke the whole menu.
Now if no file exists it will show a message that there is no file and return, preventing the error.

If a user manually messes with the json and sets values incorrectly, this bug could come back. However, I think that would be not worth the hassle of dealing with unless it suddenly becomes a common issue.