### PR TITLE
Update OSexIntegrationMain.psc

### DIFF
--- a/Scripts/Source/OSexIntegrationMain.psc
+++ b/Scripts/Source/OSexIntegrationMain.psc
@@ -1967,7 +1967,7 @@ Function Orgasm(Actor Act)
 	SendModEvent("ostim_orgasm")
 
 	; added by subhuman
-	if Game.IsPluginInstalled("Fertility Mode.esm")
+	if Game.IsPluginInstalled("Fertility Mode.esm") && IsVaginal()
 		int handle = ModEvent.Create("FertilityModeAddSperm")
 		if handle
 			ModEvent.PushForm(handle, GetSexPartner(Act) as form)

--- a/Scripts/Source/OSexIntegrationMain.psc
+++ b/Scripts/Source/OSexIntegrationMain.psc
@@ -1965,6 +1965,21 @@ EndFunction
 Function Orgasm(Actor Act)
 	SetActorExcitement(Act, -3.0)
 	SendModEvent("ostim_orgasm")
+
+	; added by subhuman
+	if Game.IsPluginInstalled("Fertility Mode.esm")
+		int handle = ModEvent.Create("FertilityModeAddSperm")
+		if handle
+			ModEvent.PushForm(handle, GetSexPartner(Act) as form)
+			ModEvent.PushString(handle, Act.GetDisplayName())
+			if Game.IsPluginInstalled("Fertility Mode 3 Fixes and Updates.esp")
+				ModEvent.PushForm(handle, Act as form)
+			endIf
+			ModEvent.Send(handle)
+		endIf
+	endIf
+	; end added by subhuman
+
 	OrgasmSound.Play(Act)
 	If (Act == PlayerRef)
 		NutEffect.Apply()


### PR DESCRIPTION
If Fertility Mode is installed, sends the FertilityModeAddSperm event with proper parameters
if Fertilty Mode 3 Fixes and Updates is installed, includes the orgasming actor as form (optional parameter, but without it I will direct any and all user complaints about children being of weird races to you, since I cannot be sure of the father race with only a name in the case of generic actors such as Imperial Soldiers that can be of multiple races!  :P )