### PR TITLE
Adds easier settings sharing support for Modlist authors.

### DIFF
--- a/Scripts/Source/OSexIntegrationMCM.psc
+++ b/Scripts/Source/OSexIntegrationMCM.psc
@@ -860,9 +860,14 @@ EndFunction
 Function ImportSettings()
 	; Import from file.
 	int OstimSettingsFile = JValue.readFromFile(JContainers.UserDirectory() + "OstimMCMSettings.json")
-	if (OstimSettingsFile == False)
+	; Tries to import from Data folder as well, this is to allow Modlist creators to package configuration files as mods for mo2 or vortex.
+	int OstimSettingsFileAlt = JValue.readFromFile(".\\Data\\OstimMCMSettings.json")
+	if (OstimSettingsFile == False && OstimSettingsFileAlt == False)
 		Debug.MessageBox("Tried to import from file, but no file existed.")
 		return
+	ElseIf (OstimSettingsFile == False && OstimSettingsFileAlt == True)
+		OstimSettingsFile = OstimSettingsFileAlt
+		Debug.MessageBox("Importing modlist settings from file, wait a second or two before clicking OK.")
 	Else
 		Debug.MessageBox("Importing from file, wait a second or two before clicking OK.")
 	EndIf


### PR DESCRIPTION
This will add the ability to quickly share ostim MCM setting like a regular mo2 or Vortex mod.
This way, rather than having to tell users of a modlist to "Grab these random files and put them in this random directory"
They can just tell the user, "install this mod" and this does the rest.