### PR TITLE
fix: swapped scenes for SoloAnimsInstalled & ThreesomeAnimsInstalled

### DIFF
--- a/Scripts/Source/OSexIntegrationMain.psc
+++ b/Scripts/Source/OSexIntegrationMain.psc
@@ -1029,11 +1029,11 @@ Int Function GetAPIVersion()
 EndFunction
 
 bool Function SoloAnimsInstalled()
-	return MiscUtil.FileExists("data/meshes/0SA/mod/0Sex/scene/0M2F/Sy6KNy2Sy9/DHJ/Parlor0BJ2HJ.xml")
+	return MiscUtil.FileExists("data/meshes/0SA/mod/0Sex/scene/WANK/Boy9/Sx/AnubsMagicDildoBentOver.xml")
 EndFunction
 
 bool Function ThreesomeAnimsInstalled()
-	return MiscUtil.FileExists("data/meshes/0SA/mod/0Sex/scene/WANK/Boy9/Sx/AnubsMagicDildoBentOver.xml")
+	return MiscUtil.FileExists("data/meshes/0SA/mod/0Sex/scene/0M2F/Sy6KNy2Sy9/DHJ/Parlor0BJ2HJ.xml")
 EndFunction
 
 Function IncreaseAnimationSpeed()


### PR DESCRIPTION
I noticed that SoloAnimsInstalled() and ThreesomeAnimsInstalled() were referencing the wrong animations, so I swapped them.